### PR TITLE
CPU Halt on unsupported instructions replaced with TrapHandler.throwI…

### DIFF
--- a/src/main/java/com/cburch/logisim/riscv/cpu/ArithmeticInstruction.java
+++ b/src/main/java/com/cburch/logisim/riscv/cpu/ArithmeticInstruction.java
@@ -5,6 +5,8 @@ public class ArithmeticInstruction {
     public static void executeImmediate(rv32imData hartData) {
         InstructionRegister ir = hartData.getIR();
         long rs1 = hartData.getX(ir.rs1());
+        boolean illegalInstructionExceptionTriggered = false;
+
         switch (ir.func3()) {
             case 0x0:   // addi rd,rs1,imm_I
                 hartData.setX(ir.rd(), rs1 + ir.imm_I());
@@ -30,7 +32,7 @@ public class ArithmeticInstruction {
                         hartData.setX(ir.rd(), rs1 >> ir.rs2());
                         break;
                     default:
-                        hartData.halt();
+                        illegalInstructionExceptionTriggered = true;
                 }
                 break;
             case 0x6:   // ori rd,rs1,imm_I
@@ -40,14 +42,19 @@ public class ArithmeticInstruction {
                 hartData.setX(ir.rd(), rs1 & ir.imm_I());
                 break;
             default:
-                hartData.halt();
+                illegalInstructionExceptionTriggered = true;
         }
+
+        if(illegalInstructionExceptionTriggered)TrapHandler.throwIllegalInstructionException(hartData);
+        else hartData.getPC().increment();
     }
 
     private static void executeArithmetic(rv32imData hartData) {
         InstructionRegister ir = hartData.getIR();
         long rs1 = hartData.getX(ir.rs1());
         long rs2 = hartData.getX(ir.rs2());
+        boolean illegalInstructionExceptionTriggered = false;
+
         switch (ir.func3()) {
             case 0x0:
                 switch (ir.func7()) {
@@ -58,7 +65,7 @@ public class ArithmeticInstruction {
                         hartData.setX(ir.rd(), (int) (rs1 - rs2));
                         break;
                     default:
-                        hartData.halt();
+                        illegalInstructionExceptionTriggered = true;
                 }
                 break;
             case 0x1:   // sll rd,rs1,rs2
@@ -82,7 +89,7 @@ public class ArithmeticInstruction {
                         hartData.setX(ir.rd(), (int) rs1 >> (rs2 & 0x1f));
                         break;
                     default:
-                        hartData.halt();
+                        illegalInstructionExceptionTriggered = true;
                 }
                 break;
             case 0x6:   // or rd,rs1,rs2
@@ -92,15 +99,18 @@ public class ArithmeticInstruction {
                 hartData.setX(ir.rd(),rs1 & rs2);
                 break;
             default:
-                hartData.halt();
+                illegalInstructionExceptionTriggered = true;
         }
+
+        if(illegalInstructionExceptionTriggered)TrapHandler.throwIllegalInstructionException(hartData);
+        else hartData.getPC().increment();
     }
 
     private static void executeMultiplicationDivision(rv32imData hartData) {
         InstructionRegister ir = hartData.getIR();
         long rs1 = hartData.getX(ir.rs1());
         long rs2 = hartData.getX(ir.rs2());
-
+        boolean illegalInstructionExceptionTriggered = false;
         // Refer to specification for division/mod by zero:
         // https://riscv.org/wp-content/uploads/2017/05/riscv-spec-v2.2.pdf
         // (page 36)
@@ -163,8 +173,10 @@ public class ArithmeticInstruction {
                 hartData.setX(ir.rd(), Integer.remainderUnsigned((int)rs1,(int)rs2));
                 break;
             default:
-                hartData.halt();
+                illegalInstructionExceptionTriggered = true;
         }
+        if(illegalInstructionExceptionTriggered)TrapHandler.throwIllegalInstructionException(hartData);
+        else hartData.getPC().increment();
     }
     public static void executeRegister(rv32imData hartData) {
         InstructionRegister ir = hartData.getIR();

--- a/src/main/java/com/cburch/logisim/riscv/cpu/BranchInstruction.java
+++ b/src/main/java/com/cburch/logisim/riscv/cpu/BranchInstruction.java
@@ -5,6 +5,7 @@ public class BranchInstruction {
     public static void execute(rv32imData hartData) {
         InstructionRegister ir = hartData.getIR();
         boolean takeBranch = false;
+        boolean illegalInstructionExceptionTriggered = false;
 
         switch (ir.func3()) {
             case 0x0:   // beq rs1, rs2, label
@@ -38,12 +39,16 @@ public class BranchInstruction {
                 }
                 break;
             default:
-                hartData.halt();
+                illegalInstructionExceptionTriggered = true;
         }
 
-        if (takeBranch) {
+        if (illegalInstructionExceptionTriggered) {
+            TrapHandler.throwIllegalInstructionException(hartData);
+        }
+        else if(takeBranch) {
             hartData.getPC().set(hartData.getPC().get() + ir.imm_B());
-        } else {
+        }
+        else {
             hartData.getPC().increment();
         }
     }

--- a/src/main/java/com/cburch/logisim/riscv/cpu/LoadInstruction.java
+++ b/src/main/java/com/cburch/logisim/riscv/cpu/LoadInstruction.java
@@ -27,12 +27,19 @@ public class LoadInstruction {
             case 0x5:  // lhu rd, imm(rs1)
                 hartData.setX(ir.rd(), getUnsignedDataHalf(data, address));
                 break;
-            default:
-                hartData.halt();
         }
+        hartData.getPC().increment();
     }
 
     public static void performAddressing(rv32imData hartData) {
+
+        //never reach latch step if instruction is invalid
+        InstructionRegister ir = hartData.getIR();
+        if(!(ir.func3() == 0x0 || ir.func3() == 0x1 || ir.func3() == 0x2 || ir.func3() == 0x4 || ir.func3() == 0x5)) {
+            TrapHandler.throwIllegalInstructionException(hartData);
+            return;
+        }
+
         hartData.setFetching(false);
         hartData.setAddressing(true);
 

--- a/src/main/java/com/cburch/logisim/riscv/cpu/StoreInstruction.java
+++ b/src/main/java/com/cburch/logisim/riscv/cpu/StoreInstruction.java
@@ -6,6 +6,13 @@ import com.cburch.logisim.data.Value;
 public class StoreInstruction {
 
     public static void performAddressing(rv32imData hartData) {
+
+        InstructionRegister ir = hartData.getIR();
+        if(!(ir.func3() == 0x0 || ir.func3() == 0x1 || ir.func3() == 0x2)) {
+            TrapHandler.throwIllegalInstructionException(hartData);
+            return;
+        }
+
         hartData.setFetching(false);
         hartData.setAddressing(true);
 
@@ -13,26 +20,7 @@ public class StoreInstruction {
         hartData.setLastAddress(getAddress(hartData).toLongValue());
 
         // Values for outputs fetching data
-        hartData.setAddress(Value.createKnown(
-                32, hartData.getLastAddress() - get2LSB(hartData) ) );
-
-        // Check for correct offset
-        if (hartData.getOutputDataWidth() == 2) {
-            if (get2LSB(hartData) != 0 && get2LSB(hartData) != 2) {
-                hartData.halt();
-                hartData.setMemWrite(Value.FALSE);
-                return;
-            }
-        }
-
-        if (hartData.getOutputDataWidth() == 4) {
-            if (get2LSB(hartData) != 0) {
-                hartData.halt();
-                hartData.setMemWrite(Value.FALSE);
-                return;
-            }
-        }
-
+        hartData.setAddress(Value.createKnown(32, hartData.getLastAddress() - get2LSB(hartData)));
         hartData.setMemRead(Value.TRUE);
         hartData.setMemWrite(Value.TRUE);
         hartData.setIsSync(Value.TRUE);
@@ -96,8 +84,6 @@ public class StoreInstruction {
                 hartData.setOutputDataWidth(4);
                 result = Value.createKnown(BitWidth.create(32), (data ^ 0x80000000L) - 0x80000000L);
                 break;
-            default:
-                hartData.halt();
         }
 
         return result;

--- a/src/main/java/com/cburch/logisim/riscv/cpu/SystemInstruction.java
+++ b/src/main/java/com/cburch/logisim/riscv/cpu/SystemInstruction.java
@@ -4,36 +4,38 @@ import com.cburch.logisim.riscv.cpu.csrs.*;
 import static com.cburch.logisim.riscv.cpu.csrs.MMCSR.*;
 
 public class SystemInstruction {
-    public static void execute(rv32imData state) {
-        int funct3 = state.getIR().func3();
-        int csr = state.getIR().csr();
-        int rd = state.getIR().rd();
-        int rs1 = state.getIR().rs1();
-        long imm_I = state.getIR().imm_I();
-        long rs1Value = state.getX(rs1);
+    public static void execute(rv32imData hartData) {
+        InstructionRegister ir = hartData.getIR();
+        int funct3 = ir.func3();
+        int csr = ir.csr();
+        int rd = ir.rd();
+        int rs1 = ir.rs1();
+        long imm_I = ir.imm_I();
+        long rs1Value = hartData.getX(rs1);
         long csrValue;
         long result;
+        boolean illegalInstructionExceptionTriggered = false;
 
         switch (funct3) {
             case 0x0: { // ecall/ebreak/_ret
-                MSTATUS_CSR mstatus = ((MSTATUS_CSR) MMCSR.getCSR(state, MSTATUS));
+                MSTATUS_CSR mstatus = ((MSTATUS_CSR) MMCSR.getCSR(hartData, MSTATUS));
                 if (imm_I == 0) {
                     // ecall
                     MSTATUS_CSR.MPP mpp = (MSTATUS_CSR.MPP)mstatus.MPP;
                     switch(mpp.getLastPrivilegeMode()){
                         case USER:
-                            TrapHandler.handle(state, MCAUSE_CSR.TRAP_CAUSE.ENVIRONMENT_CALL_FROM_U_MODE);
+                            TrapHandler.handle(hartData, MCAUSE_CSR.TRAP_CAUSE.ENVIRONMENT_CALL_FROM_U_MODE);
                             break;
                         case SUPERVISOR:
-                            TrapHandler.handle(state, MCAUSE_CSR.TRAP_CAUSE.ENVIRONMENT_CALL_FROM_S_MODE);
+                            TrapHandler.handle(hartData, MCAUSE_CSR.TRAP_CAUSE.ENVIRONMENT_CALL_FROM_S_MODE);
                             break;
                         case MACHINE:
-                            TrapHandler.handle(state, MCAUSE_CSR.TRAP_CAUSE.ENVIRONMENT_CALL_FROM_M_MODE);
+                            TrapHandler.handle(hartData, MCAUSE_CSR.TRAP_CAUSE.ENVIRONMENT_CALL_FROM_M_MODE);
                             break;
                     }
                 } else if (imm_I == 1) {
                     //ebreak
-                    TrapHandler.handle(state, MCAUSE_CSR.TRAP_CAUSE.BREAKPOINT);
+                    TrapHandler.handle(hartData, MCAUSE_CSR.TRAP_CAUSE.BREAKPOINT);
                 } else if (rs1 == 0 && rd == 0 && csr == 0x2) {
                     // uret
                     // PC = uepc
@@ -42,56 +44,58 @@ public class SystemInstruction {
                     // PC = sepc
                 } else if (rs1 == 0 && rd == 0 && csr == 0x302) {
                     // mret
-                    state.getPC().set(MMCSR.getValue(state, MEPC) );
+                    hartData.getPC().set(MMCSR.getValue(hartData, MEPC) );
                     mstatus.MIE.set(mstatus.MPIE.get());
                     mstatus.MPIE.set(1);
-                    CSR mip =  MMCSR.getCSR(state, MIP);
+                    CSR mip =  MMCSR.getCSR(hartData, MIP);
                     mip.write(mip.read() & (~0x80));
                     // set MPP to user mode if implemented
                     mstatus.MPP.set(PRIVILEGE_MODE.MACHINE.getValue());
+                } else {
+                    illegalInstructionExceptionTriggered = true;
                 }
                 break;
             }
             case 0x1: // csrrw rd,csr,rs1
-                csrValue = state.getCSRValue(csr);
+                csrValue = hartData.getCSRValue(csr);
                 result = rs1Value;
-                state.setCSR(csr, result);
-                state.setX(rd, csrValue);
+                hartData.setCSR(csr, result);
+                hartData.setX(rd, csrValue);
                 break;
             case 0x2: // csrrs rd,csr,rs1
-                csrValue = state.getCSRValue(csr);
+                csrValue = hartData.getCSRValue(csr);
                 result = csrValue | rs1Value;
-                state.setCSR(csr, result);
-                state.setX(rd, csrValue);
+                hartData.setCSR(csr, result);
+                hartData.setX(rd, csrValue);
                 break;
             case 0x3: // csrrc rd,csr,rs1
-                csrValue = state.getCSRValue(csr);
+                csrValue = hartData.getCSRValue(csr);
                 result = csrValue & ~rs1Value;
-                state.setCSR(csr, result);
-                state.setX(rd, csrValue);
+                hartData.setCSR(csr, result);
+                hartData.setX(rd, csrValue);
                 break;
             case 0x5: // csrrwi rd,csr,uimm
-                csrValue = state.getCSRValue(csr);
-                result = state.getIR().rs1();
-                state.setCSR(csr, result);
-                state.setX(rd, csrValue);
+                csrValue = hartData.getCSRValue(csr);
+                result = hartData.getIR().rs1();
+                hartData.setCSR(csr, result);
+                hartData.setX(rd, csrValue);
                 break;
             case 0x6: // csrrsi rd,csr,uimm
-                csrValue = state.getCSRValue(csr);
-                result = csrValue | state.getIR().rs1();
-                state.setCSR(csr, result);
-                state.setX(rd, csrValue);
+                csrValue = hartData.getCSRValue(csr);
+                result = csrValue | hartData.getIR().rs1();
+                hartData.setCSR(csr, result);
+                hartData.setX(rd, csrValue);
                 break;
             case 0x7: // csrrci rd,csr,uimm
-                csrValue = state.getCSRValue(csr);
-                result = csrValue & ~state.getIR().rs1();
-                state.setCSR(csr, result);
-                state.setX(rd, csrValue);
+                csrValue = hartData.getCSRValue(csr);
+                result = csrValue & ~hartData.getIR().rs1();
+                hartData.setCSR(csr, result);
+                hartData.setX(rd, csrValue);
                 break;
             default:
-                state.halt();
-                break;
+                illegalInstructionExceptionTriggered = true;
         }
+        if(illegalInstructionExceptionTriggered) TrapHandler.throwIllegalInstructionException(hartData);
+        else if(funct3 != 0x0) hartData.getPC().increment();
     }
-
 }

--- a/src/main/java/com/cburch/logisim/riscv/cpu/rv32imData.java
+++ b/src/main/java/com/cburch/logisim/riscv/cpu/rv32imData.java
@@ -151,12 +151,10 @@ public class rv32imData implements InstanceData, Cloneable {
     switch(ir.opcode()) {
       case 0x13:  // I-type arithmetic instruction
         ArithmeticInstruction.executeImmediate(this);
-        pc.increment();
         fetchNextInstruction();
         break;
       case 0x33:  // R-type arithmetic & multiplication and division instructions
         ArithmeticInstruction.executeRegister(this);
-        pc.increment();
         fetchNextInstruction();
         break;
       case 0x03:  // load instruction (I-type)
@@ -164,13 +162,12 @@ public class rv32imData implements InstanceData, Cloneable {
           LoadInstruction.performAddressing(this);
         } else {
           LoadInstruction.latch(this, dataIn);
-          pc.increment();
           fetchNextInstruction();
         }
         break;
       case 0x23:  // storing instruction (S-type)
         StoreInstruction.performAddressing(this);
-        intermixFlag = (cpuState == CPUState.OPERATIONAL);  // WE ARE MIXING DATA ONLY WHEN INSTRUCTION DOESN'T HALT CPU!
+        intermixFlag = (addressing);
         break;
       case 0x63:  // branch instruction (B-type)
         BranchInstruction.execute(this);
@@ -198,9 +195,7 @@ public class rv32imData implements InstanceData, Cloneable {
         break;
       case 0x73:  // System instructions
         SystemInstruction.execute(this);
-        if(ir.func3() != 0x0) pc.increment();
         fetchNextInstruction();
-
         break;
       default:  // Unknown instruction
         TrapHandler.throwIllegalInstructionException(this);


### PR DESCRIPTION
…llegalInstructionException, enabled misaligned stores instead of halting CPU according to specification.